### PR TITLE
fix(transaction): reliably commit symbol selection and extend preview wait for market hours

### DIFF
--- a/fidelity/fidelity.py
+++ b/fidelity/fidelity.py
@@ -832,6 +832,15 @@ class FidelityAutomation:
             # Force the search to use exactly what was entered
             self.page.get_by_label("Symbol", exact=True).press("Enter")
 
+            # Dismiss the symbol-suggestions overlay. The current UI keeps
+            # the autocomplete dropdown OPEN after Enter: it covers the
+            # controls below (action menu, extended-hours toggle, preview
+            # button) so later clicks time out waiting for actionability,
+            # and a force-clicked control behind it can land on a
+            # suggestion row and silently swap the committed symbol
+            # (observed 2026-06-12: SPY became SPYM that way).
+            self.page.keyboard.press("Escape")
+
             # Wait for quote panel to show up
             self.page.locator("#quote-panel").wait_for(timeout=5000)
             
@@ -948,7 +957,10 @@ class FidelityAutomation:
 
             # If error occurred
             try:
-                self.page.get_by_role("button", name="Place order", exact=False).wait_for(timeout=5000, state="visible")
+                # 20s, not 5s: during market hours the preview does live
+                # pricing/buying-power checks and regularly takes >5s to
+                # surface the Place order button (observed 2026-06-12).
+                self.page.get_by_role("button", name="Place order", exact=False).wait_for(timeout=20000, state="visible")
             except PlaywrightTimeoutError:
                 # Error must be present (or really slow page for some reason)
                 # Try to report on error

--- a/fidelity/fidelity.py
+++ b/fidelity/fidelity.py
@@ -829,17 +829,31 @@ class FidelityAutomation:
             self.page.get_by_label("Symbol", exact=True).click()
             # Fill in the ticker
             self.page.get_by_label("Symbol", exact=True).fill(stock)
-            # Force the search to use exactly what was entered
-            self.page.get_by_label("Symbol", exact=True).press("Enter")
-
-            # Dismiss the symbol-suggestions overlay. The current UI keeps
-            # the autocomplete dropdown OPEN after Enter: it covers the
-            # controls below (action menu, extended-hours toggle, preview
-            # button) so later clicks time out waiting for actionability,
-            # and a force-clicked control behind it can land on a
-            # suggestion row and silently swap the committed symbol
-            # (observed 2026-06-12: SPY became SPYM that way).
-            self.page.keyboard.press("Escape")
+            # Commit the symbol by clicking its EXACT row in the suggestions
+            # dropdown — that selects it AND closes the overlay. Enter alone
+            # leaves the dropdown open over the form controls (later clicks
+            # time out on actionability, and a force-clicked control behind
+            # it can land on a suggestion row and silently swap the symbol —
+            # SPY became SPYM that way on 2026-06-12). Escape does NOT
+            # dismiss this widget (verified same day).
+            committed = False
+            try:
+                exact_row = self.page.get_by_role("option").filter(
+                    has_text=re.compile(rf"^\s*{re.escape(stock.upper())}\b"))
+                if exact_row.count() > 0:
+                    exact_row.first.click(timeout=3000)
+                    committed = True
+            except Exception:
+                committed = False
+            if not committed:
+                # Fallback: commit with Enter, then click neutral page space
+                # (mid-page, below the ticket controls) to dismiss the
+                # overlay via outside-click.
+                self.page.get_by_label("Symbol", exact=True).press("Enter")
+                try:
+                    self.page.mouse.click(640, 330)
+                except Exception:
+                    pass
 
             # Wait for quote panel to show up
             self.page.locator("#quote-panel").wait_for(timeout=5000)


### PR DESCRIPTION
## Summary

This PR fixes two reliability issues in `Fidelity.transaction()` (`fidelity/fidelity.py`) related to symbol entry and order preview timing.

## Changes

### 1. Commit the symbol by clicking its exact suggestion row
Previously the code committed the ticker by pressing `Enter` after filling the Symbol field. This left the autocomplete dropdown open over the form controls, which caused two problems:
- Later clicks would time out on actionability because the overlay covered the controls.
- A force-clicked control behind the overlay could land on a suggestion row and silently swap the symbol (e.g. `SPY` became `SPYM` on 2026-06-12).

The new logic locates the suggestion row whose text exactly matches the entered ticker and clicks it, which both selects the symbol and dismisses the overlay. If no matching row is found, it falls back to pressing `Enter` and then clicking a neutral area of the page to dismiss the dropdown via outside-click. (`Escape` was verified not to dismiss this widget.)

### 2. Increase the "Place order" button wait from 5s to 20s
During market hours the preview performs live pricing and buying-power checks that regularly take longer than 5 seconds to surface the "Place order" button. The timeout was raised to 20s to avoid spurious timeouts.

## Commits
- `fix(transaction): click the exact suggestion row to commit the symbol`
- `fix(transaction): dismiss symbol autocomplete overlay + widen preview wait`

## Files changed
- `fidelity/fidelity.py` (+29 / -3)